### PR TITLE
Remove `TAny`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ matrix:
   include:
   # We grab the appropriate GHC and cabal-install versions from hvr's PPA. See:
   # https://github.com/hvr/multi-ghc-travis
-  - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 7.10.3"
-    addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
   - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 8.0.2"
     addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}

--- a/src/Solr/Query/Lucene.hs
+++ b/src/Solr/Query/Lucene.hs
@@ -44,7 +44,6 @@ module Solr.Query.Lucene
   , incl
   , excl
   , star
-  , fromMaybeStar
     -- *** @spatial predicate@ expressions
   , intersects
   , isWithin

--- a/src/Solr/Query/Lucene.hs
+++ b/src/Solr/Query/Lucene.hs
@@ -44,6 +44,7 @@ module Solr.Query.Lucene
   , incl
   , excl
   , star
+  , fromMaybeStar
     -- *** @spatial predicate@ expressions
   , intersects
   , isWithin

--- a/src/Solr/Query/Lucene/Expr.hs
+++ b/src/Solr/Query/Lucene/Expr.hs
@@ -165,7 +165,7 @@ lte e = star `to` incl e
 data Boundary ty where
   Inclusive :: LuceneExpr ty -> Boundary ty
   Exclusive :: LuceneExpr ty -> Boundary ty
-  Star :: Boundary 'TAny
+  Star :: Boundary ty
 
 deriving instance Eq (Boundary ty)
 deriving instance Show (Boundary ty)
@@ -178,9 +178,13 @@ incl = Inclusive
 excl :: LuceneExpr a -> Boundary a
 excl = Exclusive
 
--- | @\'*\'@ operator, signifying the minimum or maximun bound of a range.
+-- | @\'*\'@ operator, signifying the minimum or maximum bound of a range.
 star :: Boundary 'TAny
 star = Star
+
+-- | Returns 'Star' if Nothing
+fromMaybeStar :: Maybe (Boundary a) -> Boundary a
+fromMaybeStar = fromMaybe Star
 
 -- | @\'Intersects\'@ spatial predicate.
 intersects :: Shape -> LuceneExpr 'TSpatialPredicate

--- a/src/Solr/Query/Lucene/Expr.hs
+++ b/src/Solr/Query/Lucene/Expr.hs
@@ -112,7 +112,7 @@ datetime t =
   formatMilli ml = thawStr (tail (printf "%.5f" (ml / 100))) <> "Z\""
 
 -- | A range expression.
-to :: Rangeable a b => Boundary a -> Boundary b -> LuceneExpr 'TRange
+to :: Rangeable a => Boundary a -> Boundary a -> LuceneExpr 'TRange
 to b1 b2 = E (mconcat [lhs b1, " TO ", rhs b2])
  where
   lhs :: Boundary a -> Builder
@@ -131,7 +131,7 @@ infix 9 `to`
 -- @
 -- 'gt' e = 'excl' e \`to\` 'star'
 -- @
-gt :: Rangeable a 'TAny => LuceneExpr a -> LuceneExpr 'TRange
+gt :: Rangeable a => LuceneExpr a -> LuceneExpr 'TRange
 gt e = excl e `to` star
 
 -- | Short-hand for a greater-than-or-equal-to range query.
@@ -139,7 +139,7 @@ gt e = excl e `to` star
 -- @
 -- 'gte' e = 'incl' e \`to\` 'star'
 -- @
-gte :: Rangeable a 'TAny => LuceneExpr a -> LuceneExpr 'TRange
+gte :: Rangeable a => LuceneExpr a -> LuceneExpr 'TRange
 gte e = incl e `to` star
 
 -- | Short-hand for a less-than range query.
@@ -147,7 +147,7 @@ gte e = incl e `to` star
 -- @
 --  'lt' e = 'star' \`to\` 'excl' e
 -- @
-lt :: Rangeable 'TAny a => LuceneExpr a -> LuceneExpr 'TRange
+lt :: Rangeable a => LuceneExpr a -> LuceneExpr 'TRange
 lt e = star `to` excl e
 
 -- | Short-hand for a less-than-or-equal-to range query.
@@ -155,7 +155,7 @@ lt e = star `to` excl e
 -- @
 -- 'lte' e = 'star' \`to\` 'incl' e
 -- @
-lte :: Rangeable 'TAny a => LuceneExpr a -> LuceneExpr 'TRange
+lte :: Rangeable a => LuceneExpr a -> LuceneExpr 'TRange
 lte e = star `to` incl e
 
 -- | An inclusive or exclusive expression for use in a range query, built with
@@ -179,12 +179,8 @@ excl :: LuceneExpr a -> Boundary a
 excl = Exclusive
 
 -- | @\'*\'@ operator, signifying the minimum or maximum bound of a range.
-star :: Boundary 'TAny
+star :: Boundary a
 star = Star
-
--- | Returns 'Star' if Nothing
-fromMaybeStar :: Maybe (Boundary a) -> Boundary a
-fromMaybeStar = fromMaybe Star
 
 -- | @\'Intersects\'@ spatial predicate.
 intersects :: Shape -> LuceneExpr 'TSpatialPredicate

--- a/src/Solr/Query/Lucene/Expr/Type.hs
+++ b/src/Solr/Query/Lucene/Expr/Type.hs
@@ -12,8 +12,7 @@ import GHC.TypeLits (TypeError, ErrorMessage(..))
 #endif
 
 data LuceneExprTy
-  = TAny
-  | TNum
+  = TNum
   | TBool
   | TWord
   | TWild
@@ -29,19 +28,12 @@ instance Boostable 'TWord
 instance Boostable 'TPhrase
 
 -- | 'int's, 'float's, 'word's, and 'datetime's can 'to' range expression.
-class Rangeable (a :: LuceneExprTy) (b :: LuceneExprTy)
-instance Rangeable 'TNum      'TNum
-instance Rangeable 'TNum      'TAny
-instance Rangeable 'TWord     'TWord
-instance Rangeable 'TWord     'TAny
-instance Rangeable 'TDateTime 'TDateTime
-instance Rangeable 'TDateTime 'TAny
-instance Rangeable 'TAny      'TNum
-instance Rangeable 'TAny      'TWord
-instance Rangeable 'TAny      'TDateTime
-instance Rangeable 'TAny      'TAny
+class Rangeable (a :: LuceneExprTy)
+instance Rangeable 'TNum
+instance Rangeable 'TWord
+instance Rangeable 'TDateTime
 
 #if MIN_VERSION_base(4,9,0)
 instance {-# OVERLAPPABLE #-} TypeError ('Text "You can only boost words and phrases") => Boostable a
-instance {-# OVERLAPPABLE #-} TypeError ('Text "You can only use numbers, words, and dates in a range expression") => Rangeable a b
+instance {-# OVERLAPPABLE #-} TypeError ('Text "You can only use numbers, words, and dates in a range expression") => Rangeable a
 #endif

--- a/test/Solr/Query/LuceneSpec.hs
+++ b/test/Solr/Query/LuceneSpec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TypeApplications #-}
+
 module Solr.Query.LuceneSpec where
 
 import Solr.Query
@@ -51,7 +53,7 @@ spec =
       it "clamps millisecond 99.999 <-" (test def ("foo" =: datetime (2015, 1, 1, 1, 1, 1, 100)) "q=foo:\"2015-01-01T01:01:01.99999Z\"")
 
     describe "range" $ do
-      it "[* TO *]" (test def ("foo" =: star `to` star) "q=foo:[* TO *]")
+      it "[* TO *]" (test def ("foo" =: (star @ 'TNum) `to` star) "q=foo:[* TO *]")
 
       describe "int" $ do
         it "incl/incl" (test def ("foo" =: incl (int 5) `to` incl (int 6)) "q=foo:[5 TO 6]")
@@ -96,7 +98,7 @@ spec =
         it "excl/excl" (test def ("foo" =: excl (datetime t1) `to` excl (datetime t2)) "q=foo:{\"2015-01-01T00:00:00Z\" TO \"2016-01-01T00:00:00Z\"}")
         it "star/incl" (test def ("foo" =: star `to` incl (datetime t1)) "q=foo:[* TO \"2015-01-01T00:00:00Z\"]")
         it "incl/star" (test def ("foo" =: incl (datetime t1) `to` star) "q=foo:[\"2015-01-01T00:00:00Z\" TO *]")
-        it "star/star" (test def ("foo" =: star `to` star) "q=foo:[* TO *]")
+        it "star/star" (test def ("foo" =: (star @ 'TNum) `to` star) "q=foo:[* TO *]")
         it "gt" (test def ("foo" =: gt (datetime t1)) "q=foo:{\"2015-01-01T00:00:00Z\" TO *]")
         it "gte" (test def ("foo" =: gte (datetime t1)) "q=foo:[\"2015-01-01T00:00:00Z\" TO *]")
         it "lt" (test def ("foo" =: lt (datetime t1)) "q=foo:[* TO \"2015-01-01T00:00:00Z\"}")


### PR DESCRIPTION
This involved changing the `Boundary` datatype from `Star -> Boundary TAny` to `Star -> Boundary ty`. This should not affect type inference as `Star` is not exported, but `star :: Boundary TAny` is. So `to star star` does not need an explicit type signature.